### PR TITLE
DC constants fixes

### DIFF
--- a/holoclean/holoclean.py
+++ b/holoclean/holoclean.py
@@ -297,7 +297,7 @@ class Session:
         if self.holo_env.verbose:
             end = time.time()
             log = 'Time to Load Data: ' + str(end - start) + '\n'
-            print log
+            print(log)
         attributes = self.dataset.get_schema('Init')
         for attribute in attributes:
             self.holo_env.dataengine.add_db_table_index(
@@ -399,7 +399,7 @@ class Session:
         if self.holo_env.verbose:
             end = time.time()
             log = 'Time for Error Detection: ' + str(end - start) + '\n'
-            print log
+            print(log)
 
         return clean, dk
 
@@ -452,7 +452,7 @@ class Session:
             if self.holo_env.verbose:
                 end = time.time()
                 log = 'Time for Training Model: ' + str(end - start) + '\n'
-                print log
+                print(log)
                 self.holo_env.logger.info('Time for Training Model: ' +
                                           str(end - start))
                 start = time.time()
@@ -468,7 +468,7 @@ class Session:
             if self.holo_env.verbose:
                 end = time.time()
                 log = 'Time for Test Featurization: ' + str(end - start) + '\n'
-                print log
+                print(log)
                 self.holo_env.logger.\
                     info('Time for Test Featurization dk: ' + str(end - start))
                 start = time.time()
@@ -478,7 +478,7 @@ class Session:
             if self.holo_env.verbose:
                 end = time.time()
                 log = 'Time for Inference: ' + str(end - start) + '\n'
-                print log
+                print(log)
                 self.holo_env.logger.info('Time for Inference: ' +
                                           str(end - start))
 

--- a/holoclean/holoclean.py
+++ b/holoclean/holoclean.py
@@ -347,6 +347,7 @@ class Session:
         if index < 0 or index >= len(self.Denial_constraints):
             raise IndexError("Given Index Out Of Bounds")
 
+        self.dc_objects.pop(self.Denial_constraints[index])
         return self.Denial_constraints.pop(index)
 
     def load_clean_data(self, file_path):

--- a/holoclean/utils/parser_interface.py
+++ b/holoclean/utils/parser_interface.py
@@ -183,10 +183,8 @@ class DenialConstraint:
                 append(Predicate(split[i], self.tuple_names, schema))
 
         # Create CNF form of the DC
-        for predicate in self.predicates:
-            self.cnf_form += predicate.cnf_form
-            self.cnf_form += " AND "
-        self.cnf_form = self.cnf_form[:-5]  # remove AND and spaces at the end
+        cnf_forms = [predicate.cnf_form for predicate in self.predicates]
+        self.cnf_form = " AND ".join(cnf_forms)
         return
 
     @staticmethod


### PR DESCRIPTION
* Fixed removing dc_object from dc_objects, when deleting a dc.
NOTE: Looks like it was being used down stream in at least two places, where things where accessing dc_objects directly.
* added some python sugar for building up dc string
* fixing print statement (python2 = :crying_cat_face: )