### PR TITLE
Checking Number of Tuples Per Predicate

### DIFF
--- a/holoclean/utils/parser_interface.py
+++ b/holoclean/utils/parser_interface.py
@@ -84,6 +84,17 @@ class Predicate:
 
         :return: list of predicate components
         """
+
+        # HC currently only supports DCs with two tuples per predicate
+        # so raise an exception if a different number present
+        num_tuples = len(predicate_string.split(','))
+        if num_tuples < 2:
+            raise DCFormatException('Less than 2 tuples in predicate: ' +
+                                    predicate_string)
+        elif num_tuples > 2:
+            raise DCFormatException('More than 2 tuples in predicate: ' +
+                                    predicate_string)
+
         operation = self.operation_string
         if predicate_string[0:len(operation)] != operation:
             raise \


### PR DESCRIPTION
Ran into errors when made a typo and had a predicate with EQ(t1.City) alone. Now checks for these types of mistakes as it previously caused issues in error detection.

Looked for other format checking we can do, but didn't find anything obvious in the time I spent. Would like to flesh out with unit tests and other fun, but that can wait until after finals.