### PR TITLE
Add setup.py for packaging, update gitignore with packaging stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ _templates
 **/dataset_id.txt
 **/execution_time.txt
 .DS_store
+build/
+dist/
+holoclean.egg-info/
+

--- a/README.md
+++ b/README.md
@@ -133,7 +133,22 @@ Check if you have JDK 8 by running
 <br>
 If you do not have JDK 8, download and install JDK 8 for MacOS from the oracle website: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 
-### 6. Getting Started
+### 6. Install  Spark
+<br/>
+<b>6.1 For Ubuntu</b>
+To install Spark, you'll need to download it directly from the Spark [downloads](https://spark.apache.org/downloads.html) page
+<br/>
+<b>6.2 For MacOS</b>
+To install Spark on MacOS run
+
+```
+brew install apache-spark
+```
+
+After installation of spark, add a `SPARK_HOME` environment variable to your shell, and add `/usr/local/Cellar/apache-spark/<version>/libexec/python` to 
+your python path.
+
+### 7. Getting Started
 To get started, the following tutorials in the tutorial directory will get you familiar with the HoloClean framework
 <br>
 To run the tutorials in Jupyter Notebook go to the root directory in the terminal and run

--- a/README.md
+++ b/README.md
@@ -134,10 +134,14 @@ Check if you have JDK 8 by running
 If you do not have JDK 8, download and install JDK 8 for MacOS from the oracle website: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 
 ### 6. Install  Spark
-<br/>
+<br>
+
 <b>6.1 For Ubuntu</b>
-To install Spark, you'll need to download it directly from the Spark [downloads](https://spark.apache.org/downloads.html) page
-<br/>
+
+To install Spark, you'll need to download it directly from the Spark [downloads](https://spark.apache.org/downloads.html) page.
+
+<br>
+
 <b>6.2 For MacOS</b>
 To install Spark on MacOS run
 

--- a/README.md
+++ b/README.md
@@ -133,16 +133,8 @@ Check if you have JDK 8 by running
 <br>
 If you do not have JDK 8, download and install JDK 8 for MacOS from the oracle website: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
 
-### 6. Install  Spark
-<br>
+### 6. Install  Spark (MacOS only)
 
-<b>6.1 For Ubuntu</b>
-
-To install Spark, you'll need to download it directly from the Spark [downloads](https://spark.apache.org/downloads.html) page.
-
-<br>
-
-<b>6.2 For MacOS</b>
 To install Spark on MacOS run
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,88 @@
+'''
+    setup.py
+    Setup file to make installing holoclean easier
+'''
+
+from setuptools import setup
+
+with open("README.md", 'r') as f:
+    long_description = f.read()
+
+setup(
+    name='holoclean',
+    version='0.1.0',
+    description='Holoclean is a statistical inference engine to impute, clean, and enrich data.',
+    author='HoloClean',
+    author_email='contact@holoclean.io',
+    license='Apache License 2.0',
+    url='http://www.holoclean.io/',
+    packages=['holoclean'],
+    install_requires=[
+        'backports-abc==0.5',
+        'backports.shutil-get-terminal-size==1.0.0',
+        'bleach==2.1.3',
+        'certifi==2016.2.28',
+        'click==6.7',
+        'configparser==3.5.0',
+        'decorator==4.2.1',
+        'Distance==0.1.3',
+        'entrypoints==0.2.3',
+        'enum34==1.1.6',
+        'funcsigs==1.0.2',
+        'functools32==3.2.3.post2',
+        'future==0.16.0',
+        'futures==3.2.0',
+        'html5lib==1.0.1',
+        'ipykernel==4.8.2',
+        'ipython==5.6.0',
+        'ipython-genutils==0.2.0',
+        'ipywidgets==7.2.0',
+        'Jinja2==2.10',
+        'jsonschema==2.6.0',
+        'jupyter==1.0.0',
+        'jupyter-client==5.2.3',
+        'jupyter-console==5.2.0',
+        'jupyter-core==4.4.0',
+        'llvmlite==0.22.0',
+        'MarkupSafe==1.0',
+        'mistune==0.8.3',
+        'nbconvert==5.3.1',
+        'nbformat==4.4.0',
+        'notebook==5.4.1',
+        'numba==0.37.0',
+        'numpy==1.14.2',
+        'pandocfilters==1.4.2',
+        'pathlib2==2.3.0',
+        'pexpect==4.4.0',
+        'pickleshare==0.7.4',
+        'Pillow==5.1.0',
+        'prompt-toolkit==1.0.15',
+        'psycopg2==2.7.4',
+        'psycopg2-binary==2.7.4',
+        'ptyprocess==0.5.2',
+        'py4j==0.10.6',
+        'Pygments==2.2.0',
+        'pyspark==2.3.0',
+        'python-dateutil==2.7.2',
+        'PyYAML==3.12',
+        'pyzmq==17.0.0',
+        'qtconsole==4.3.1',
+        'scandir==1.7',
+        'scipy==1.0.1',
+        'Send2Trash==1.5.0',
+        'simplegeneric==0.8.1',
+        'singledispatch==3.4.0.3',
+        'six==1.11.0',
+        'terminado==0.8.1',
+        'testpath==0.3.1',
+        'torch==0.3.1',
+        'torchvision==0.2.0',
+        'tornado==5.0.1',
+        'tqdm==4.20.0',
+        'traitlets==4.3.2',
+        'wcwidth==0.1.7',
+        'webencodings==0.5.1',
+        'widgetsnbextension==3.2.0'
+    ]
+)
+


### PR DESCRIPTION
Add setup.py for a little bit easier installing and import
Benefits are:
- Easy upload to pip, just run:
python setup.py register
python setup.py --sign upload
- install holoclean (and all dependencies) directly to python packages, just run
python setup.py install

This should deprecate the need to update PYTHONPATH in set_env.sh and let you import holoclean from anywhere as long as you have your virtualenv activated.